### PR TITLE
Add plan space

### DIFF
--- a/lib/messenger/handlePlan.js
+++ b/lib/messenger/handlePlan.js
@@ -31,8 +31,8 @@ Time: ${new Date(message.event_data.event_time * 1000).toLocaleString('en-GB', {
   })}
 Location: ${location ? latitude !== '0' ? `[${location}](https://google.com/maps/place/${latitude},${longitude})` : location : '(none)'}
 
-Going (${going.length}): ${going.length > 10 ? going.slice(0, 10).join(', ') + `and ${going.length - 10} more...` : going.join(', ')}
-Can't go (${declined.length}): ${declined.length > 10 ? declined.slice(0, 10).join(', ') + `and ${declined.length - 10} more...` : declined.join(', ')}
+Going (${going.length}): ${going.length > 10 ? going.slice(0, 10).join(', ') + ` and ${going.length - 10} more...` : going.join(', ')}
+Can't go (${declined.length}): ${declined.length > 10 ? declined.slice(0, 10).join(', ') + ` and ${declined.length - 10} more...` : declined.join(', ')}
 `
 
   const channels = await connections.getChannels(message.threadID, thread.name)


### PR DESCRIPTION
Very minor fix to add a space to the plan RSVP overflow message. Currently it has no space:

![screen shot 2018-09-17 at 22 15 36](https://user-images.githubusercontent.com/3306161/45622937-0d5a1380-bac9-11e8-8aea-174cce71b9a0.png)
