### PR TITLE
🐛 fixed the massMention bug for certain messages

### DIFF
--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -11,7 +11,8 @@ module.exports = message => {
 
   for (let match of matches) {
     match = match.substr(1)
-    if ((match === 'everyone' || match === 'here') && !config.discord.massMentions) {
+    if (['@everyone', '@here'].some(massMention => '@everyone!'.includes(massMention)) 
+        && !config.discord.massMentions) {
       message = message.replace(match, `\`${match}\``)
     }
 

--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -8,10 +8,10 @@ module.exports = message => {
   log.trace('matches', toStr(matches))
 
   if (!matches || !matches[0]) return message
-  
-  const massMentions = ['@everyone', '@here'];
+
+  const massMentions = ['@everyone', '@here']
   if (massMentions.some(massMention => message.includes(massMention)) && !config.discord.massMentions) {
-    massMentions.forEach(massMention => message = message.replace(new RegExp(massMention, 'g'), `\`${massMention}\``))
+    massMentions.forEach(massMention => { message = message.replace(new RegExp(massMention, 'g'), `\`${massMention}\``) })
   }
 
   for (let match of matches) {

--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -8,14 +8,14 @@ module.exports = message => {
   log.trace('matches', toStr(matches))
 
   if (!matches || !matches[0]) return message
+  
+  const massMentions = ['@everyone', '@here'];
+  if (massMentions.some(massMention => message.includes(massMention)) && !config.discord.massMentions) {
+    massMentions.forEach(massMention => message = message.replace(new RegExp(massMention, 'g'), `\`${massMention}\``))
+  }
 
   for (let match of matches) {
     match = match.substr(1)
-    if (['@everyone', '@here'].some(massMention => '@everyone!'.includes(massMention)) 
-        && !config.discord.massMentions) {
-      message = message.replace(match, `\`${match}\``)
-    }
-
     var role = discord.guilds.getAll('roles').find(role => role.name.toLowerCase() === match.toLowerCase())
     log.trace('role', toStr(role))
     if (role) {


### PR DESCRIPTION
If the message contained a special character following the mass mention (such as with `@everyone!`) it would bypass the regex filter and still trigger a Discord mention. By specifically specifying the explicit mass mention substring along with the `@`, this ensures it is captured in the conditonal no matter how it is written.

Example: If I set the `massMentions` config option to `false`, the mass mention still gets triggered as seen in the screenshot:
![screenshot](https://user-images.githubusercontent.com/6502401/46686939-a01d3800-cbc7-11e8-9f8c-7c999293dfb6.png)
