### PR TITLE
💄 added userMentions config option

### DIFF
--- a/lib/config/getConfig.js
+++ b/lib/config/getConfig.js
@@ -21,7 +21,8 @@ const defaultConfig = {
     showEvents: false,
     showFullNames: false,
     createChannels: false,
-    massMentions: true
+    massMentions: true,
+    userMentions: true
   },
   timestamps: {
     console: false,

--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -4,15 +4,15 @@ const log = logger.withScope('handleMentions')
 module.exports = message => {
   log.trace('message', message)
 
-  var matches = message.match(/@[^# ]{2,32}/g)
-  log.trace('matches', toStr(matches))
-
-  if (!matches || !matches[0]) return message
-
   const massMentions = ['@everyone', '@here']
   if (massMentions.some(massMention => message.includes(massMention)) && !config.discord.massMentions) {
     massMentions.forEach(massMention => { message = message.replace(new RegExp(massMention, 'g'), `\`${massMention}\``) })
   }
+
+  var matches = message.match(/@[^# ]{2,32}/g)
+  log.trace('matches', toStr(matches))
+
+  if (!matches || !matches[0] || !config.discord.userMentions) return message
 
   for (let match of matches) {
     match = match.substr(1)


### PR DESCRIPTION
Currently there's no option to turn off user mentions triggered from Messenger to Discord. This often leads to many wrongly mentioned users who have multi-word names on Discord but where the single word name already exists. For example, if `Dan The Man` was the name a Messenger user tried to trigger, but the user `Dan` already exists, `Dan` would be unintentionally mentioned.

Fixes #272.