### PR TITLE
Fixed bug where Webhooks would create like crazy.

### DIFF
--- a/lib/createMessage/fromDiscord.discord.js
+++ b/lib/createMessage/fromDiscord.discord.js
@@ -1,7 +1,7 @@
-const handleEmojis = require('../discord/handleEmojis')
+// Webhooks do NOT support cross server emojis.
 module.exports = message => {
   return {
-    body: handleEmojis(message.content),
+    body: message.content,
     opts: {
       embeds: message.embeds,
       username: message.author.username,

--- a/lib/createMessage/fromDiscord.discord.js
+++ b/lib/createMessage/fromDiscord.discord.js
@@ -1,4 +1,4 @@
-const handleEmojis = require('./discord/handleEmojis')
+const handleEmojis = require('../discord/handleEmojis')
 module.exports = message => {
   return {
     body: handleEmojis(message.content),

--- a/lib/createMessage/fromMessenger.discord.js
+++ b/lib/createMessage/fromMessenger.discord.js
@@ -1,5 +1,6 @@
 const log = logger.withScope('createMessage:fromMessenger:discord')
 const handleMentions = require('../discord/handleMentions')
+const handleEmojis = require('../discord/handleEmojis')
 const emojiCount = require('./emojiCount')
 const getAttachmentURL = require('./getAttachmentURL')
 const thumbs = [ 369239263222822, 369239383222810, 369239343222814 ]
@@ -10,7 +11,7 @@ module.exports = async (thread, sender, message) => {
   let authorName
   ({ authorName, message } = parseMessengerMessage(thread, sender, message))
 
-  let body = handleMentions(message.message)
+  let body = handleEmojis(handleMentions(message.message))
   if (body.length > 2000) body = body.slice(0, 1997) + '...'
 
   // if there are no attachments, send it already

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -18,7 +18,7 @@ module.exports = message => {
     const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(/:/g, '').toLowerCase())
     if (emoji) {
       log.debug(`found an emoji ${match}`)
-      message = message.replace(new RegExp(match, 'g'), emoji)
+      message = message.replace(new RegExp(match, 'g'), emoji.toString())
       emojiParsed.push(match)
     } else {
       log.debug(`No emoji found for ${match}...`)

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -3,7 +3,7 @@
 */
 const log = logger.withScope('handleEmojis')
 module.exports = message => {
-  const matches = message.match(/:{2,32}:/g)
+  const matches = message.match(/:[^ ].*:/g)
   log.trace('Emojis found', matches)
   log.debug(`found an emoji ${matches}`)
   if (!matches || !matches[0]) return message

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -5,9 +5,10 @@ const log = logger.withScope('handleEmojis')
 module.exports = message => {
   const matches = message.match(/:{2,32}:/g)
   log.trace('Emojis found', matches)
-
+  log.debug(`found an emoji ${matches}`)
   if (!matches || !matches[0]) return message
   // Match first result and attach it as emote will not parse otherwise.
+  log.debug(`Trying to find ${matches}`)
   for (let match of matches) {
     const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(/:/g, '').toLowerCase())
     if (emoji) {

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -1,7 +1,7 @@
 /*
   This will grab any emojis being sent and parse them we do this as Bots have built in nitro.
 */
-const log = logger.withScope('handleMentions')
+const log = logger.withScope('handleEmojis')
 module.exports = message => {
   const matches = message.match(/:{2,32}:/g)
   log.trace('Emojis found', matches)

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -9,10 +9,12 @@ module.exports = message => {
   if (!matches || !matches[0]) return message
   // Match first result and attach it as emote will not parse otherwise.
   for (let match of matches) {
-    const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(':', '').toLowerCase())
+    const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(/:/g, '').toLowerCase())
     if (emoji) {
       log.debug(`found an emoji ${match}`)
-      message = message.replace(`@${match}`, emoji)
+      message = message.replace(`${match}`, emoji)
+    } else {
+      log.debug(`No emoji found for ${match}...`)
     }
   }
   return message

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -9,7 +9,7 @@ module.exports = message => {
   if (!matches || !matches[0]) return message
   // Match first result and attach it as emote will not parse otherwise.
   for (let match of matches) {
-    const emoji = discord.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(':', '').toLowerCase())
+    const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(':', '').toLowerCase())
     if (emoji) {
       log.debug(`found an emoji ${match}`)
       message = message.replace(`@${match}`, emoji)

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -3,23 +3,18 @@
 */
 const log = logger.withScope('handleEmojis')
 module.exports = message => {
-  const matches = message.match(/:[^: ]*:/g)
+  let matches = message.match(/:[^: ]*:/g)
   if (!matches || !matches[0]) return message
   log.trace('Emojis found', matches)
   log.debug(`found an emoji ${matches}`)
   // Match first result and attach it as emote will not parse otherwise.
   // We must use a handler to track which emojis have already been used.
-  let emojiParsed = []
+  matches = [...new Set(matches)] // removes duplicates
   for (let match of matches) {
-    if (emojiParsed.includes(match)) {
-      log.debug(`Emoji ${match} has already been parsed.`)
-      continue
-    }
     const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(/:/g, '').toLowerCase())
     if (emoji) {
       log.debug(`found an emoji ${match}`)
       message = message.replace(new RegExp(match, 'g'), emoji.toString())
-      emojiParsed.push(match)
     } else {
       log.debug(`No emoji found for ${match}...`)
     }

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -8,12 +8,18 @@ module.exports = message => {
   log.trace('Emojis found', matches)
   log.debug(`found an emoji ${matches}`)
   // Match first result and attach it as emote will not parse otherwise.
-  log.debug(`Trying to find ${matches}`)
+  // We must use a handler to track which emojis have already been used.
+  let emojiParsed = []
   for (let match of matches) {
+    if (emojiParsed.includes(match)) {
+      log.debug(`Emoji ${match} has already been parsed.`)
+      continue
+    }
     const emoji = discord.client.emojis.find(emoji => emoji.name.toLowerCase() === match.replace(/:/g, '').toLowerCase())
     if (emoji) {
       log.debug(`found an emoji ${match}`)
-      message = message.replace(`${match}`, emoji)
+      message = message.replace(new RegExp(match, 'g'), emoji)
+      emojiParsed.push(match)
     } else {
       log.debug(`No emoji found for ${match}...`)
     }

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -4,9 +4,9 @@
 const log = logger.withScope('handleEmojis')
 module.exports = message => {
   const matches = message.match(/:[^ ].*:/g)
+  if (!matches || !matches[0]) return message
   log.trace('Emojis found', matches)
   log.debug(`found an emoji ${matches}`)
-  if (!matches || !matches[0]) return message
   // Match first result and attach it as emote will not parse otherwise.
   log.debug(`Trying to find ${matches}`)
   for (let match of matches) {

--- a/lib/discord/handleEmojis.js
+++ b/lib/discord/handleEmojis.js
@@ -3,7 +3,7 @@
 */
 const log = logger.withScope('handleEmojis')
 module.exports = message => {
-  const matches = message.match(/:[^ ].*:/g)
+  const matches = message.match(/:[^: ]*:/g)
   if (!matches || !matches[0]) return message
   log.trace('Emojis found', matches)
   log.debug(`found an emoji ${matches}`)

--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -43,6 +43,7 @@ module.exports = message => {
     if (user) {
       log.debug(`Mentioning user ${match}`)
       if (user === 'deleted-role') {
+        log.debug(`deleted-role found? ${match}`)
         log.trace('deleted-role found?')
       } else {
         message = message.replace(`@${match}`, user)

--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -3,26 +3,37 @@
 const log = logger.withScope('handleMentions')
 module.exports = message => {
   log.trace('message', message)
-
+  //Handles @everyone / @here, goes through the message replacing plaintext with the proper mentions.
   const massMentions = ['@everyone', '@here']
   if (massMentions.some(massMention => message.includes(massMention)) && !config.discord.massMentions) {
     massMentions.forEach(massMention => { message = message.replace(new RegExp(massMention, 'g'), `\`${massMention}\``) })
   }
-
+  //Finds any potential @s and excludes anything preceeding spaces/hashtags within a 2-32 character limit globally.
   const matches = message.match(/@[^# ]{2,32}/g)
   log.trace('matches', matches)
-
+  //If no matches, or usermentions is disabled, return.
   if (!matches || !matches[0] || !config.discord.userMentions) return message
+  /*
+    We go through each role or user match finding first roles.
+    If no role is found, we then find a user.
 
+    Bug: If a role is found in one server, it will copy the role ID to other servers
+    this will show "@deleted-role" for other servers, similarly if we copy a user ID that
+    does not exist in the server, they will not be pingable which is OK. We should only
+    ping the user once and just utilize the topmost server.
+  */
   for (let match of matches) {
+    //Exclude @
     match = match.substr(1)
+    //Go through each role in each guild the bot is in, and try to find the role.
     const role = discord.guilds.getAll('roles').find(role => role.name.toLowerCase() === match.toLowerCase())
     log.trace('role', role)
     if (role) {
       log.debug(`Mentioning role ${match}`)
       if (!role.mentionable) log.warn(`Role ${match} not mentionable!`)
       message = message.replace(`@${match}`, role)
-      break
+      //break //Breaks if the role is not mentionable/deleted, have it continue instead.
+      continue
     }
 
     const user = discord.guilds.getAll('members').find(user =>

--- a/lib/discord/handleMentions.js
+++ b/lib/discord/handleMentions.js
@@ -30,8 +30,11 @@ module.exports = message => {
     log.trace('role', role)
     if (role) {
       log.debug(`Mentioning role ${match}`)
-      if (!role.mentionable) log.warn(`Role ${match} not mentionable!`)
-      message = message.replace(`@${match}`, role)
+      if (!role.mentionable) {
+        // if role is not mentionable, omit.
+        log.warn(`Role ${match} not mentionable!`)
+        message = message.replace(`@${match}`, role)
+      }
       continue
     }
 
@@ -40,6 +43,7 @@ module.exports = message => {
       (user.user.username.toLowerCase() === match.toLowerCase())
     )
     log.trace('user', user)
+    // TODO: Get current guild being parsed so we can check if user.id is present in guild
     if (user) {
       log.debug(`Mentioning user ${match}`)
       if (user === 'deleted-role') {

--- a/lib/discord/login.js
+++ b/lib/discord/login.js
@@ -28,7 +28,10 @@ It's not an error... unless you added the bot to your guild already.`)
       if (!guild) throw new Error(`Guild ${config.discord.guild} was not found!`)
       // move OUR guild to the front.
       var first = guild
-      discord.guilds.sort(function (x, y) { return x === first ? -1 : y === first ? 1 : 0 })
+      discord.guilds = [
+        guild,
+        ...discord.guilds.filter(_guild => _guild.id !== guild.id)
+      ]
     }
     discord.guilds.getAll = name => [].concat(...discord.guilds.map(guild => guild[name].array()))
     log.debug('Found Discord guild(s)')

--- a/lib/discord/login.js
+++ b/lib/discord/login.js
@@ -27,7 +27,6 @@ It's not an error... unless you added the bot to your guild already.`)
       const guild = client.guilds.find(guild => guild.name.toLowerCase() === config.discord.guild.toLowerCase() || guild.id === config.discord.guild)
       if (!guild) throw new Error(`Guild ${config.discord.guild} was not found!`)
       // move OUR guild to the front.
-      var first = guild
       discord.guilds = [
         guild,
         ...discord.guilds.filter(_guild => _guild.id !== guild.id)

--- a/lib/discord/login.js
+++ b/lib/discord/login.js
@@ -22,12 +22,13 @@ It's not an error... unless you added the bot to your guild already.`)
     }
 
     // set guild as a global variable, if it's specified in arguments then get it by name, if not then get the first one
+    discord.guilds = client.guilds.array()
     if (config.discord.guild) {
       const guild = client.guilds.find(guild => guild.name.toLowerCase() === config.discord.guild.toLowerCase() || guild.id === config.discord.guild)
       if (!guild) throw new Error(`Guild ${config.discord.guild} was not found!`)
-      discord.guilds = [ guild ]
-    } else {
-      discord.guilds = client.guilds.array()
+      // move OUR guild to the front.
+      var first = guild
+      discord.guilds.sort(function (x, y) { return x === first ? -1 : y === first ? 1 : 0 })
     }
     discord.guilds.getAll = name => [].concat(...discord.guilds.map(guild => guild[name].array()))
     log.debug('Found Discord guild(s)')


### PR DESCRIPTION
How to reproduce: Specify a guild ID and then multilink servers.

Fix: By default it will now grab all guilds rather than a single if a guild ID is specified. The guild that is specified will then be pushing to position 0 as categorys is dependent on it being in the first position.