### PR TITLE
Update discordapp->discord links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The following is a set of guidelines for contributing to Miscord and its package
 
 We have an official Discord server where the community chimes in with helpful advice if you have questions.
 
-[![Discord](https://discordapp.com/api/guilds/431471556540104724/embed.png)](https://discord.gg/DkmTvVz)
+[![Discord](https://discord.com/api/guilds/431471556540104724/embed.png)](https://discord.gg/DkmTvVz)
 
 Also, take a look at our FAQ (`#faq` on Discord or [wiki/FAQ](https://wiki.miscord.net/FAQ))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ We have an official Discord server where the community chimes in with helpful ad
 
 [![Discord](https://discord.com/api/guilds/431471556540104724/embed.png)](https://discord.gg/DkmTvVz)
 
-Also, take a look at our FAQ (`#faq` on Discord or [wiki/FAQ](https://wiki.miscord.net/FAQ))
+Also, take a look at our FAQ (`#faq` on Discord or [FAQ](https://docs.miscord.net/faq) in docs)
 
 ## How Can I Contribute?
 
@@ -42,7 +42,7 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 
 #### Before Submitting A Bug Report
 
-* **Check the [FAQ](https://github.com/miscord/miscord/wiki/FAQ) and try changing log level.** You might be able to find the cause of the problem and fix things yourself. Most importantly, check if you can reproduce the problem [in the latest version of Miscord](https://github.com/miscord/miscord/wiki/Updating).
+* **Check the [FAQ](https://docs.miscord.net/faq) and try changing log level.** You might be able to find the cause of the problem and fix things yourself. Most importantly, check if you can reproduce the problem [in the latest version of Miscord](https://github.com/miscord/miscord/wiki/Updating).
 * **Perform a [cursory search](https://github.com/miscord/miscord/issues)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Bug Report?

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://liberapay.com/Miscord/donate"><img alt="Donate using Liberapay" src="https://img.shields.io/liberapay/receives/Miscord?logo=liberapay&style=for-the-badge"></a>
   <a href="https://www.bountysource.com/teams/miscord/issues"><img alt="Bountysource" src="https://img.shields.io/bountysource/team/miscord/activity?style=for-the-badge"></a>
   <br />
-  <a href="https://discord.gg/DkmTvVz"><img src="https://discordapp.com/api/guilds/431471556540104724/embed.png" alt="Discord"></a>
+  <a href="https://discord.gg/DkmTvVz"><img src="https://discord.com/api/guilds/431471556540104724/embed.png" alt="Discord"></a>
 </p>
 
 > Built on [libfb](https://github.com/ChatPlug/libfb-js) and [discord.js](https://discord.js.org)

--- a/src/ConnectionsManager.ts
+++ b/src/ConnectionsManager.ts
@@ -137,7 +137,7 @@ export default class ConnectionsManager extends Collection<string, Connection> {
   async save (): Promise<void> {
     const yamlConnections: YAMLConnections = Object.assign(
       {
-        __comment: 'This is your connections.yml file. More info at https://github.com/miscord/miscord/wiki/Connections.yml'
+        __comment: 'This is your connections.yml file. More info at https://docs.miscord.net/configuration/connections.yml'
       },
       ...this.map(connection => connection.toYAMLObject())
     )

--- a/src/discord/login.ts
+++ b/src/discord/login.ts
@@ -30,7 +30,7 @@ export default async function login (): Promise<Client | FakeClient> {
   if (client.guilds.size === 0 && client instanceof Client) {
     throw new Error(`No guilds added!
 You can add a bot to your guild here:
-https://discordapp.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=537390096&scope=bot
+https://discord.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=537390096&scope=bot
 It's not an error... unless you added the bot to your guild already.`)
   }
   // set guild as a global variable, if it's specified in arguments then get it by name, if not then get the first one

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -31,7 +31,7 @@ class Channel {
   }
 
   get link () {
-    return `https://discordapp.com/channels/${this.guild.id}/${this.id}`
+    return `https://discord.com/channels/${this.guild.id}/${this.id}`
   }
 }
 


### PR DESCRIPTION
> In May 2020, Discord changed its primary domain from discordapp.com to discord.com.

source:
- [Wikipedia:Discord (software)](https://en.wikipedia.org/wiki/Discord_(software)#cite_ref-20:~:text=In%20April%202020%2C%20Discord's%20Twitter%20username,primary%20domain%20from%20discordapp.com%20to%20discord.com.%5B22%5D)

The links redirect, so not a critical change yet.